### PR TITLE
Reload load_order.txt from disk before applying create/delete events

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,190 @@
+# RGSS Script Editor — Fork Notes
+
+This is a personal fork of [`SnowSzn/rgss-script-editor`](https://github.com/SnowSzn/rgss-script-editor),
+pinned to upstream **v1.6.1**. It adds two small, additive safety changes so
+`load_order.txt` and the scripts folder can be edited by hand (terminal, git,
+any text editor) **without the extension silently clobbering those edits**,
+while leaving every GUI-driven code path unchanged.
+
+Packaged as a distinct extension id (`SnowSzn.rgss-script-editor-fork`,
+displayed as **RGSS Script Editor (Fork)**) so VS Code's update check can't
+silently reinstall the Marketplace build over it.
+
+---
+
+## What changed
+
+1. **No-picker reload command** — `rgss-script-editor.reloadFromLoadOrder`
+   forces a full reload from disk (re-reads `load_order.txt`, rescans the
+   folder, re-saves) without the workspace-folder quick-pick. Reuses the
+   existing `setProjectFolder()` pipeline. No keybinding is shipped; bind it in
+   your personal `keybindings.json`:
+
+   ```json
+   {
+     "key": "ctrl+alt+r",
+     "command": "rgss-script-editor.reloadFromLoadOrder",
+     "when": "rgss-script-editor.openedFolder"
+   }
+   ```
+
+2. **Watchers resync from disk before persisting** — the external
+   file-create/delete watchers (`watcherScriptOnDidCreate` /
+   `watcherScriptOnDidDelete` in `manager.ts`) now call
+   `ScriptsController.syncFromDisk()` before saving. `syncFromDisk()` rebuilds
+   the in-memory tree from what's currently on disk (load order file + folder
+   scan) so the subsequent `load_order.txt` save reflects your hand-edits plus
+   the new event, instead of overwriting them with a stale in-memory snapshot.
+
+   `syncFromDisk()` was extracted out of `_restart()` so both paths share one
+   implementation.
+
+### Note on the watcher implementation vs. the original design doc
+
+The original design doc proposed calling `syncFromDisk()` at the very top of
+each watcher and leaving the rest of each handler untouched. That doesn't quite
+work: `syncFromDisk()` runs a folder `_scan()`, which **already** adds a
+newly-created file to the tree. The handler's existing `sectionFind(uri)` guard
+then sees the file is "already there" and returns early — **skipping the
+`refresh()` that actually writes `load_order.txt` and updates the sidebar**. The
+delete handler short-circuits the same way (the deleted file is already gone
+from the resynced tree, so `findChild` finds nothing and never reaches
+`refresh()`).
+
+Net effect of the literal design-doc version: hand-edits are preserved, but an
+externally created/deleted script isn't written into `load_order.txt` (and so
+isn't loaded by the game, and the sidebar looks stale) until the next reload.
+
+This fork restructures the two handlers so the resync happens first and
+`refresh()` **always** runs afterward for relevant events. Result: hand-edits
+are preserved **and** external create/delete is persisted immediately. Upstream
+already saved on every watcher event, so this isn't extra write risk — it just
+saves from the correct (resynced) tree. Irrelevant events (non-Ruby files,
+`load_order.txt` itself) still early-return with no save, exactly as upstream.
+
+> If you ever want the ultra-conservative behavior instead — where the
+> extension never auto-writes `load_order.txt` in response to an external event
+> and you always force persistence with the reload hotkey — revert the two
+> watcher handlers to a bare `syncFromDisk()` at the top with the original body
+> below it. The tradeoff is that new files won't be in `load_order.txt` until
+> you reload.
+
+### Known side effect
+
+`syncFromDisk()` clears the cut/copy clipboard (same as a full restart). So if
+you cut or copy sections in the tree and an external file create/delete fires
+before you paste, the clipboard is emptied. Rare in practice; it's the accepted
+tradeoff for always resyncing from disk.
+
+### Deliberately out of scope
+
+No resync hook is added to the GUI section commands
+(`sectionCreate` / `sectionDelete` / `sectionRename` / `sectionMove` /
+`sectionPaste` / `sectionToggleLoad`) or to `refresh()` generally. Those
+commands receive an already-resolved tree-node object from VS Code's UI layer
+before the code runs; `syncFromDisk()` would rebuild the tree with new object
+instances and orphan that reference (silent no-op, or in rename's case a real
+filesystem rename against a detached object that never gets saved back — a
+dangling `load_order.txt` entry). This is inherent to click-time argument
+resolution.
+
+---
+
+## Manual regression checklist
+
+Run this in the **Extension Development Host** (press **F5** in this repo, then
+open a real RPG Maker project in the new window) before trusting a new build.
+The "code-traced" notes below record what was verified statically against the
+source; the interactive run is still the real confirmation.
+
+### Safety — the whole point of the fork
+
+- [ ] **Hand-edit + external create.** In a terminal, reorder two lines in
+      `load_order.txt`, save. Then `touch` a new `.rb` file in the scripts
+      folder from outside VS Code. → `load_order.txt` keeps your reordering and
+      appends **only** the new file; the new script appears in the sidebar.
+      _(Code-traced: create handler resyncs from the reordered file, scan picks
+      up the new `.rb`, `refresh()` persists reorder + append.)_
+
+- [ ] **Hand-edit + external delete.** Reorder two lines in `load_order.txt`,
+      save. Then delete a tracked `.rb` file from a terminal. → `load_order.txt`
+      keeps your reordering and drops **only** the deleted file's line; the
+      section disappears from the sidebar. _(Code-traced: delete handler
+      confirms the file was tracked, resyncs (missing file dropped),
+      `refresh()` persists.)_
+
+- [ ] **Reload hotkey with only a manual edit pending.** Reorder lines in
+      `load_order.txt` with **no** file add/delete, save, then fire
+      `ctrl+alt+r` (or run "RGSS Script Editor: Reload From Load Order File"
+      from the command palette). → The sidebar reflects the new order.
+
+- [ ] **Deleting `load_order.txt` itself does not auto-recreate it** from a
+      watcher event (it's only recreated on a full reload). _(Code-traced:
+      delete handler ignores untracked paths.)_
+
+- [ ] **Creating a non-Ruby file** (e.g. `notes.txt`) in the scripts folder
+      does not rewrite `load_order.txt`. _(Code-traced: unsupported type
+      early-returns.)_
+
+### GUI section commands — must be byte-for-byte identical to upstream
+
+These paths were **not** touched; any difference from the stock extension means
+something regressed. Run each once in the dev host:
+
+- [ ] Create a script / folder / separator from the tree view.
+- [ ] Delete a section from the tree view.
+- [ ] Rename a section.
+- [ ] Move a section via drag-and-drop.
+- [ ] Cut / copy and paste a section.
+- [ ] Toggle a section's load status (checkbox).
+- [ ] Toggle-collapse a folder.
+
+### Extension identity
+
+- [ ] Extensions list shows **RGSS Script Editor (Fork)** `1.7.0` with id
+      `SnowSzn.rgss-script-editor-fork`, distinct from the Marketplace build.
+- [ ] Only one build watches the scripts folder at a time — disable/uninstall
+      the Marketplace `SnowSzn.rgss-script-editor` for this workspace. (Two
+      watchers on the same `**` glob both mutating `load_order.txt` is not a
+      supported configuration.)
+
+---
+
+## Keeping it rebasable against upstream
+
+The changes are small, additive, and isolated to `manager.ts` and
+`scripts_controller.ts` plus two registration blocks (`extension.ts`,
+`package.json`), so pulling a newer upstream release is straightforward. You
+likely won't need this often, but when you do:
+
+```sh
+# One-time: add the upstream remote (read-only; we never push to it).
+git remote add upstream https://github.com/SnowSzn/rgss-script-editor.git
+
+# When you want a newer upstream version:
+git fetch upstream --tags
+
+# Inspect available tags and pick the one you want (e.g. v1.7.0).
+git tag -l | sort -V | tail
+
+# Rebase this fork's commits onto the new upstream tag.
+git rebase <new-tag>        # e.g. git rebase v1.7.0
+```
+
+Because neither change touches the GUI section-command bodies, the UI layer, or
+the config/gameplay controllers, conflicts should be limited to line-number
+drift inside `_restart()` and the two watcher functions — not logic collisions.
+Resolve, re-run `yarn run compile`, then walk the regression checklist above.
+
+After rebasing, **re-apply the packaging identity** if upstream's `package.json`
+overwrote it: `name` → `rgss-script-editor-fork`, `displayName` →
+`RGSS Script Editor (Fork)`, and bump `version` above the upstream base. Then
+repackage:
+
+```sh
+mkdir -p dist
+npx @vscode/vsce package --out ./dist/rgss-script-editor-fork-<version>.vsix
+```
+
+Install via **Extensions: Install from VSIX…** and disable the Marketplace
+original for the workspace.

--- a/FORK.md
+++ b/FORK.md
@@ -1,7 +1,9 @@
 # RGSS Script Editor — Fork Notes
 
 This is a personal fork of [`SnowSzn/rgss-script-editor`](https://github.com/SnowSzn/rgss-script-editor),
-pinned to upstream **v1.6.1**. It adds two small, additive safety changes so
+based on upstream commit `052c782` (**version 1.6.1** — upstream doesn't tag
+releases, so the pin is a commit, not a tag). It adds two small, additive
+safety changes so
 `load_order.txt` and the scripts folder can be edited by hand (terminal, git,
 any text editor) **without the extension silently clobbering those edits**,
 while leaving every GUI-driven code path unchanged.
@@ -157,18 +159,27 @@ The changes are small, additive, and isolated to `manager.ts` and
 `package.json`), so pulling a newer upstream release is straightforward. You
 likely won't need this often, but when you do:
 
+> **Note:** upstream does **not** publish git tags or GitHub releases — it
+> versions via `package.json` (`"version"`) and `feat: version X` commit
+> messages, and its default branch is `master`. So you rebase onto a commit,
+> not a tag. This fork is currently based on `upstream/master` @ `052c782`
+> (v1.6.1), which was its tip at fork time.
+
 ```sh
-# One-time: add the upstream remote (read-only; we never push to it).
+# One-time: add the upstream remote, fetch-only (never push to SnowSzn's repo).
 git remote add upstream https://github.com/SnowSzn/rgss-script-editor.git
+git remote set-url --push upstream DISABLED
 
-# When you want a newer upstream version:
-git fetch upstream --tags
+# When you want newer upstream code:
+git fetch upstream
 
-# Inspect available tags and pick the one you want (e.g. v1.7.0).
-git tag -l | sort -V | tail
+# See what version upstream/master is now, and what's new since your base.
+git show upstream/master:package.json | grep '"version"'
+git log --oneline 052c782..upstream/master
 
-# Rebase this fork's commits onto the new upstream tag.
-git rebase <new-tag>        # e.g. git rebase v1.7.0
+# Rebase this fork's commits onto the new upstream tip (or pin to a specific
+# commit hash instead of the moving branch if you want reproducibility).
+git rebase upstream/master
 ```
 
 Because neither change touches the GUI section-command bodies, the UI layer, or

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "icon": "./icons/icon.png",
-  "name": "rgss-script-editor",
-  "displayName": "RGSS Script Editor",
+  "name": "rgss-script-editor-fork",
+  "displayName": "RGSS Script Editor (Fork)",
   "description": "An extension that allows to use Visual Studio Code as the code editor for RPG Maker game projects",
   "author": {
     "name": "SnowSzn",
@@ -29,7 +29,7 @@
   "bugs": {
     "url": "https://github.com/SnowSzn/rgss-script-editor/issues"
   },
-  "version": "1.6.1",
+  "version": "1.7.0",
   "engines": {
     "vscode": "^1.84.0"
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,12 @@
         "icon": "$(folder)"
       },
       {
+        "command": "rgss-script-editor.reloadFromLoadOrder",
+        "title": "Reload From Load Order File",
+        "category": "RGSS Script Editor",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "rgss-script-editor.openProjectFolder",
         "title": "%command.openProjectFolder.title%",
         "category": "RGSS Script Editor",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,16 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
+  // Reload from load order file command (no workspace folder picker)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'rgss-script-editor.reloadFromLoadOrder',
+      () => {
+        manager.reloadFromLoadOrder();
+      }
+    )
+  );
+
   // Open project folder command
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/src/modules/manager.ts
+++ b/src/modules/manager.ts
@@ -256,6 +256,32 @@ export async function setProjectFolder(projectFolder: vscode.Uri) {
 }
 
 /**
+ * Forces a full reload of the current project from disk, re-reading
+ * ``load_order.txt`` and rescanning the scripts folder for untracked entries,
+ * without prompting the user to pick a workspace folder.
+ *
+ * This reuses the existing ``setProjectFolder()`` pipeline, so it behaves
+ * exactly like re-opening the current project folder, just without the
+ * workspace folder quick-pick.
+ *
+ * No-op if no project folder is currently active.
+ * @returns A promise.
+ */
+export async function reloadFromLoadOrder() {
+  try {
+    const info = extensionConfig.getInfo();
+    if (!info) {
+      logger.logWarning('No active project folder to reload!');
+      return;
+    }
+    await setProjectFolder(info.projectFolderPath);
+  } catch (error) {
+    logger.logErrorUnknown(error);
+    showBasicErrorMessage();
+  }
+}
+
+/**
  * Opens the working RPG Maker project folder.
  * @returns A promise
  */
@@ -1321,6 +1347,11 @@ export async function onDidChangeConfiguration(
  */
 async function watcherScriptOnDidCreate(uri: vscode.Uri) {
   try {
+    // Resync the in-memory tree with on-disk state (including any hand-edits to
+    // load_order.txt) before applying this event, so the subsequent save does
+    // not clobber external edits with a stale snapshot.
+    extensionScripts.syncFromDisk();
+
     // Check if it is root path
     if (extensionScripts.root.isPath(uri)) {
       return;
@@ -1371,6 +1402,11 @@ async function watcherScriptOnDidCreate(uri: vscode.Uri) {
  */
 async function watcherScriptOnDidDelete(uri: vscode.Uri) {
   try {
+    // Resync the in-memory tree with on-disk state (including any hand-edits to
+    // load_order.txt) before applying this event, so the subsequent save does
+    // not clobber external edits with a stale snapshot.
+    extensionScripts.syncFromDisk();
+
     logger.logInfo(`(Watcher) Entry deleted: "${uri.fsPath}"`);
 
     // Find child instance that matches the deleted path.

--- a/src/modules/manager.ts
+++ b/src/modules/manager.ts
@@ -1347,24 +1347,18 @@ export async function onDidChangeConfiguration(
  */
 async function watcherScriptOnDidCreate(uri: vscode.Uri) {
   try {
-    // Resync the in-memory tree with on-disk state (including any hand-edits to
-    // load_order.txt) before applying this event, so the subsequent save does
-    // not clobber external edits with a stale snapshot.
-    extensionScripts.syncFromDisk();
-
     // Check if it is root path
     if (extensionScripts.root.isPath(uri)) {
       return;
     }
 
-    // Determine entry type
-    logger.logInfo(`(Watcher) Entry created: "${uri.fsPath}"`);
+    // Determine entry type. Unsupported entries (e.g. load_order.txt itself, or
+    // non-Ruby files) are ignored, matching upstream, so they never trigger a
+    // load order rewrite.
     let type = extensionScripts.determineSectionType({
       sectionPath: uri.fsPath,
       isReal: true,
     });
-
-    // Checks type validness
     if (!type) {
       logger.logInfo(
         `(Watcher) Cannot determine the type of the new entry (not supported section type)`
@@ -1372,24 +1366,30 @@ async function watcherScriptOnDidCreate(uri: vscode.Uri) {
       return;
     }
 
-    // Checks if section exists already
-    if (extensionScripts.sectionFind(uri)) {
-      logger.logInfo(`(Watcher) A section already exists for: ${uri.fsPath}`);
-      return;
+    logger.logInfo(`(Watcher) Entry created: "${uri.fsPath}"`);
+
+    // Resync the in-memory tree with on-disk state (including any hand-edits to
+    // load_order.txt) BEFORE persisting, so the save reflects external edits
+    // plus this event instead of clobbering them with a stale snapshot.
+    extensionScripts.syncFromDisk();
+
+    // syncFromDisk()'s folder scan normally picks up the new entry already; add
+    // it explicitly in case a filesystem race made the scan miss it.
+    if (!extensionScripts.sectionFind(uri)) {
+      logger.logInfo(`(Watcher) Creating section: "${uri.fsPath}"`);
+      extensionScripts.sectionCreate(
+        {
+          parent: extensionScripts.root,
+          type: type,
+          uri: uri,
+        },
+        {
+          checkboxState: true,
+        }
+      );
     }
 
-    // Create new section
-    logger.logInfo(`(Watcher) Creating section: "${uri.fsPath}"`);
-    extensionScripts.sectionCreate(
-      {
-        parent: extensionScripts.root,
-        type: type,
-        uri: uri,
-      },
-      {
-        checkboxState: true,
-      }
-    );
+    // Persists load_order.txt (hand-edits + this event) and refreshes the view.
     await refresh();
   } catch (error) {
     logger.logErrorUnknown(error);
@@ -1402,26 +1402,26 @@ async function watcherScriptOnDidCreate(uri: vscode.Uri) {
  */
 async function watcherScriptOnDidDelete(uri: vscode.Uri) {
   try {
-    // Resync the in-memory tree with on-disk state (including any hand-edits to
-    // load_order.txt) before applying this event, so the subsequent save does
-    // not clobber external edits with a stale snapshot.
-    extensionScripts.syncFromDisk();
-
-    logger.logInfo(`(Watcher) Entry deleted: "${uri.fsPath}"`);
-
-    // Find child instance that matches the deleted path.
+    // Only react if the deleted entry was actually tracked in the tree. This
+    // matches upstream (which ignores deletions of untracked files) and, in
+    // particular, avoids auto-recreating load_order.txt if it is deleted. The
+    // lookup runs before the resync, while the deleted entry is still present.
     let child = extensionScripts.root.findChild((value) => {
       return value.isPath(uri);
     }, true);
-
-    // Delete child if found.
-    if (child) {
-      logger.logInfo(
-        `(Watcher) Deleting section: "${child.resourceUri.fsPath}"`
-      );
-      extensionScripts.sectionDelete(child);
-      await refresh();
+    if (!child) {
+      return;
     }
+
+    logger.logInfo(`(Watcher) Entry deleted: "${uri.fsPath}"`);
+
+    // Resync the in-memory tree with on-disk state (including any hand-edits to
+    // load_order.txt) BEFORE persisting. The deleted entry drops out because
+    // _readLoadOrder()/_scan() skip paths that no longer exist on disk.
+    extensionScripts.syncFromDisk();
+
+    // Persists load_order.txt (hand-edits minus this event) and refreshes view.
+    await refresh();
   } catch (error) {
     logger.logErrorUnknown(error);
   }

--- a/src/modules/processes/scripts_controller.ts
+++ b/src/modules/processes/scripts_controller.ts
@@ -2261,6 +2261,32 @@ export class ScriptsController {
   }
 
   /**
+   * Re-reads the load order file and rescans the scripts folder for untracked
+   * entries, rebuilding the in-memory tree from what is currently on disk.
+   *
+   * This does NOT save the load order file: callers decide when to persist the
+   * resulting tree. This lets a caller sync the in-memory tree with on-disk
+   * (possibly hand-edited) state before applying a change and saving.
+   *
+   * Clears the clipboard as a side effect (same as a full restart), since the
+   * previous clipboard entries reference tree instances that no longer exist.
+   *
+   * Assumes the scripts folder path and load order file path are already set,
+   * so it must not be called before `_restart()` has run at least once.
+   */
+  syncFromDisk() {
+    // Clears previous editor section root instance and stale clipboard
+    this._root.clear();
+    this._clipboard = [];
+
+    // Reads the load order file
+    this._readLoadOrder();
+
+    // Scans the scripts directory for new files
+    this._scan();
+  }
+
+  /**
    * Restarts this instance based on the current attributes.
    */
   private _restart() {
@@ -2271,10 +2297,8 @@ export class ScriptsController {
       return;
     }
 
-    // Clears previous editor section root instance
-    this._root.clear();
+    // Renames the root to the current scripts folder path
     this._root.rename(scriptsFolderPath);
-    this._clipboard = [];
 
     // Updates load order file path
     this._loadOrderFilePath = vscode.Uri.joinPath(
@@ -2285,11 +2309,8 @@ export class ScriptsController {
     // Create scripts folder path if it does not exists
     fileutils.createFolder(scriptsFolderPath.fsPath, { recursive: true });
 
-    // Reads the load order file
-    this._readLoadOrder();
-
-    // Scans the scripts directory for new files
-    this._scan();
+    // Rebuilds the in-memory tree from disk (load order file + folder scan)
+    this.syncFromDisk();
 
     // Saves load order after reading and scanning
     this._saveLoadOrder(this._root.nestedChildren());


### PR DESCRIPTION
This fork of SnowSzn/rgss-script-editor, based on upstream commit 052c782 (v1.6.1) , adds two small but important safety improvements so developers can hand‑edit load_order.txt or the scripts folder without those edits being silently overwritten.

What this fork does
Reload-from-disk command: Adds rgss-script-editor.reloadFromLoadOrder, a no‑picker full reload that re-reads load_order.txt and rescans the scripts folder before saving.

Safe watcher behavior: External create/delete events now resync from disk first, ensuring hand-edits are preserved and new/deleted files are immediately persisted correctly instead of being lost due to stale in-memory state.

Why it matters
Upstream watcher logic can overwrite manual edits because it saves from an outdated tree. This fork guarantees that external changes and manual edits coexist safely, with refresh() always running when needed.

Important caveats
Clipboard clears on resync: syncFromDisk() rebuilds the tree and clears cut/copy clipboard entries (same as a full restart).

GUI commands unchanged: No resync is added to GUI-driven section operations to avoid breaking VS Code’s click-time object resolution.

Extension identity changed: Packaged separately from SnowSzn.rgss-script-editor so the Marketplace version cannot overwrite it during updates.

Rebase friendliness